### PR TITLE
bug(pyo3): ensure ndarray is gated correctly

### DIFF
--- a/src/pyo3.rs
+++ b/src/pyo3.rs
@@ -79,7 +79,7 @@ where
 
 /*****************************************************************************/
 
-#[cfg(test)]
+#[cfg(all(test, feature = "ndarray"))]
 mod tests {
     use crate::sys;
     use ndarray::{arr2, Array, ArrayView2};


### PR DESCRIPTION
Fixes the issue with `ndarray` being needed in `metatensor`... [^1]

Tested with a local diff.

```diff
diff --git i/metatensor-core/Cargo.toml w/metatensor-core/Cargo.toml
index 7b5c7542..37e6797d 100644
--- i/metatensor-core/Cargo.toml
+++ w/metatensor-core/Cargo.toml
@@ -29,7 +29,7 @@ byteorder = {version = "1"}
 scopeguard = {version = "1.1"}
 num-traits = {version = "0.2", default-features = false}
 zip = {version = "2", default-features = false, features = ["deflate"]}
-dlpack = { git = "https://github.com/metatensor/dlpack.git", features=["ndarray"] }
+dlpack = { git = "https://github.com/metatensor/dlpack.git", branch="featureGate" }
 
 [build-dependencies]
 cbindgen = { version = "0.29", default-features = false }

```

[^1]: Kinda weird because `pyo3` wasn't enabled anyway but sure.