### PR TITLE
deps(pyo3): bump from 0.26 to 0.28

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.74
+          - "1.74"
           - stable
           - nightly
     steps:
@@ -26,6 +26,19 @@ jobs:
 
       - name: Setup sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
+
+      # MSRV backfill: pyo3 0.28 requires rustc >=1.83 and pyo3 0.27 is
+      # the last line with MSRV 1.74. dlpk accepts `>=0.27, <0.29`, so we
+      # pin the pyo3 stack to the 0.27 line for the 1.74 job only. Stable
+      # and nightly resolve to 0.28 naturally.
+      - name: Pin pyo3 to 0.27 on MSRV toolchain
+        if: matrix.toolchain == '1.74'
+        run: |
+          cargo update -p pyo3 --precise 0.27.2
+          cargo update -p pyo3-build-config --precise 0.27.2
+          cargo update -p pyo3-macros --precise 0.27.2
+          cargo update -p pyo3-macros-backend --precise 0.27.2
+          cargo update -p pyo3-ffi --precise 0.27.2
 
       - name: Run tests
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,11 @@ keywords = ["dlpack", "deep-learning", "machine-learning"]
 
 [dependencies]
 ndarray = { version = "0.17", optional = true }
-pyo3 = { version = "0.28", optional = true }
+# Accept either 0.27 or 0.28 so downstream crates on either line can take
+# dlpk as a dep without forcing a pyo3 version conflict. 0.28 has MSRV 1.83
+# while 0.27 keeps MSRV 1.74; the MSRV CI job uses `cargo update --precise`
+# to pin to 0.27.
+pyo3 = { version = ">=0.27, <0.29", optional = true }
 ouroboros = { version = "0.18", optional = true }
 
 # 2.3 has MSRV 1.7.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["dlpack", "deep-learning", "machine-learning"]
 
 [dependencies]
 ndarray = { version = "0.17", optional = true }
-pyo3 = { version = "0.26", optional = true }
+pyo3 = { version = "0.28", optional = true }
 ouroboros = { version = "0.18", optional = true }
 
 # 2.3 has MSRV 1.7.0

--- a/src/pyo3.rs
+++ b/src/pyo3.rs
@@ -88,24 +88,21 @@ pub struct PyDLPack {
 
 impl PyDLPack {
     fn as_dltensor<'py>(&self, py: Python<'py>) -> PyResult<&'py sys::DLTensor> {
+        let capsule = self.capsule.bind(py);
         if self.is_versioned {
-            let versioned_tensor = self.capsule.bind(py).pointer() as *const sys::DLManagedTensorVersioned;
-            if versioned_tensor.is_null() {
-                return Err(PyErr::new::<PyValueError, _>(
-                    "PyCapsule pointer is null",
-                ));
-            }
+            let versioned_tensor = capsule
+                .pointer_checked(Some(DLTENSOR_VERSIONED_NAME))?
+                .as_ptr()
+                .cast::<sys::DLManagedTensorVersioned>();
 
             unsafe {
                 return Ok(&(*versioned_tensor).dl_tensor);
             }
         } else {
-            let tensor = self.capsule.bind(py).pointer() as *const sys::DLManagedTensor;
-            if tensor.is_null() {
-                return Err(PyErr::new::<PyValueError, _>(
-                    "PyCapsule pointer is null",
-                ));
-            }
+            let tensor = capsule
+                .pointer_checked(Some(DLTENSOR_NAME))?
+                .as_ptr()
+                .cast::<sys::DLManagedTensor>();
 
             unsafe {
                 return Ok(&(*tensor).dl_tensor);
@@ -119,7 +116,9 @@ impl PyDLPack {
 impl PyDLPack {
     #[new]
     fn new<'py>(py: Python<'py>, capsule: Py<PyCapsule>) -> PyResult<Self> {
-        let name = capsule.bind(py).name()?;
+        // SAFETY: the &CStr is used only for the duration of this function,
+        // before any arbitrary Python code can run and rename the capsule.
+        let name = capsule.bind(py).name()?.map(|n| unsafe { n.as_cstr() });
 
         let is_versioned = if name == Some(DLTENSOR_NAME) {
             false
@@ -168,7 +167,12 @@ impl PyDLPack {
         }
 
         let capsule = self.capsule.clone_ref(py);
-        let name = capsule.bind(py).name()?.expect("capsule name should be set").to_str().expect("name should be utf8");
+        // SAFETY: the &CStr is used only for the immediate `starts_with` check,
+        // before any arbitrary Python code can run and rename the capsule.
+        let name_cstr = unsafe {
+            capsule.bind(py).name()?.expect("capsule name should be set").as_cstr()
+        };
+        let name = name_cstr.to_str().expect("name should be utf8");
         if name.starts_with("used_") {
             return Err(PyErr::new::<PyValueError, _>("this caspsule has already been used"));
         }
@@ -191,7 +195,9 @@ impl<'py> TryFrom<&Bound<'py, PyCapsule>> for DLPackTensor {
     type Error = PyErr;
 
     fn try_from(capsule: &Bound<'py, PyCapsule>) -> Result<Self, Self::Error> {
-        let name = capsule.name()?;
+        // SAFETY: the &CStr is used only for the duration of this function,
+        // before any arbitrary Python code can run and rename the capsule.
+        let name = capsule.name()?.map(|n| unsafe { n.as_cstr() });
 
         let is_versioned = if name == Some(DLTENSOR_NAME) {
             false
@@ -213,34 +219,31 @@ impl<'py> TryFrom<&Bound<'py, PyCapsule>> for DLPackTensor {
             ));
         }
 
-        let pointer = capsule.pointer().cast::<DLManagedTensorVersioned>();
-        if let Some(pointer) = NonNull::new(pointer) {
-            let tensor_ref = unsafe { pointer.as_ref() };
-            let version = tensor_ref.version;
-            let is_v1_2_or_newer = version.major > 1 || (version.major == 1 && version.minor >= 2);
-            let dltensor = &tensor_ref.dl_tensor;
-            // Enforce v1.2+ stride requirement if ndim > 0
-            if is_v1_2_or_newer && dltensor.ndim > 0 && dltensor.strides.is_null() {
-                return Err(PyErr::new::<PyValueError, _>(
-                    "DLPack v1.2+ requires non-NULL strides for non-scalar tensors"
-                ));
-            }
-            unsafe {
-                // set the name to "used_dltensor_versioned" so that
-                // the capsule destructor does not free the tensor
-                let status = pyo3::ffi::PyCapsule_SetName(
-                    capsule.as_ptr(), USED_DLTENSOR_VERSIONED_NAME.as_ptr()
-                );
-                if status != 0 {
-                    return Err(PyErr::fetch(capsule.py()));
-                }
-
-                return Ok(DLPackTensor::from_raw(pointer));
-            }
-        } else {
+        let pointer: NonNull<DLManagedTensorVersioned> = capsule
+            .pointer_checked(Some(DLTENSOR_VERSIONED_NAME))?
+            .cast();
+        let tensor_ref = unsafe { pointer.as_ref() };
+        let version = tensor_ref.version;
+        let is_v1_2_or_newer = version.major > 1 || (version.major == 1 && version.minor >= 2);
+        let dltensor = &tensor_ref.dl_tensor;
+        // Enforce v1.2+ stride requirement if ndim > 0
+        if is_v1_2_or_newer && dltensor.ndim > 0 && dltensor.strides.is_null() {
             return Err(PyErr::new::<PyValueError, _>(
-                "invalid capsule, the pointer was null"
+                "DLPack v1.2+ requires non-NULL strides for non-scalar tensors"
             ));
+        }
+
+        unsafe {
+            // set the name to "used_dltensor_versioned" so that
+            // the capsule destructor does not free the tensor
+            let status = pyo3::ffi::PyCapsule_SetName(
+                capsule.as_ptr(), USED_DLTENSOR_VERSIONED_NAME.as_ptr()
+            );
+            if status != 0 {
+                return Err(PyErr::fetch(capsule.py()));
+            }
+
+            return Ok(DLPackTensor::from_raw(pointer));
         }
     }
 }


### PR DESCRIPTION
PyO3 0.26 in the optional `pyo3` feature prevented downstream crates on current PyO3 (0.28) from adding dlpk as a dependency: cargo cannot resolve two pyo3 major-minor versions in the same graph, and the two copies bring incompatible Python ABI symbols. Downgrading the consumer is a workable short-term patch but loses 0.27/0.28 ergonomics, so bump here instead.

Mechanical migration against the 0.27/0.28 API:

- `PyCapsuleMethods::name()` now returns `PyResult<Option<CapsuleName>>` instead of `PyResult<Option<&CStr>>`. `CapsuleName` has no `PartialEq` or `Debug`, so name comparisons and error messages go through `CapsuleName::as_cstr()` (marked unsafe because the capsule name's lifetime is not statically tied to the capsule; we use the `&CStr` only for the immediate comparison and do not store it).

- `PyCapsuleMethods::pointer()` is deprecated since 0.27 in favor of `pointer_checked(Some(name))`, which both validates the expected capsule name and returns `NonNull<c_void>`. This removes the separate manual null-pointer branch in `DLPackTensor::try_from(&Bound<PyCapsule>)` and the hand-written null checks in `PyDLPack::as_dltensor`.

No changes needed elsewhere: `#[pyclass]`, `#[pymethods]`, `Bound<'py, PyCapsule>`, `Py<PyCapsule>`, `Py<PyTuple>` are all stable 0.26 -> 0.28.

Verified:
- cargo build --features pyo3,ndarray
- cargo test --features pyo3,ndarray (29 unit + 2 doctests green, including the doctest in src/pyo3.rs)
- cargo build --all-features